### PR TITLE
WIP: Better windows support + adjustments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,11 @@ SHELL := /bin/bash # Use bash syntax
 # Configure environment.
 # ----------------------
 
+port ?= 80
+
 export TZ=America/Sao_Paulo
 export USER_ID=$(shell id -u)
+export PORT=$(port)
 
 # @TODO Hack for MacOSX or other OS which has the same group id
 #       than the containers user.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
         GROUP_ID: "$GROUP_ID"
     hostname: app
     ports:
-      - "80:80"
+      - "$PORT:80"
       - "3000:3000"
     dns:
       - 8.8.8.8

--- a/make.bat
+++ b/make.bat
@@ -1,0 +1,36 @@
+@ECHO OFF
+
+SET TZ=America/Sao_Paulo
+SET USER_ID=1000
+SET GROUP_ID=1000
+SET CHOKIDAR_USEPOOLING=1
+SET PWD=./
+
+IF "~%2" == "~" (
+    SET PORT=80
+    echo port is 80
+) ELSE (
+    SET PORT=%2
+    echo port is %2
+)
+
+IF "~%1" == "~" (
+    SET COMMAND=run
+) ELSE (
+    SET COMMAND=%1
+)
+
+IF "%COMMAND%" == "run" (
+    docker-compose run --service-ports --rm app
+) ELSE IF "%COMMAND%" == "in" (
+    docker-compose exec app /bin/bash
+) ELSE IF "%COMMAND%" == "mysql" (
+    docker-compose exec taller-chat-db mysql
+) ELSE IF "%COMMAND%" == "stop" (
+    docker-compose stop
+) ELSE IF "%COMMAND%" == "clean" (
+    docker-compose down
+    docker rmi taller-chat-app
+) ELSE IF "%COMMAND%" == "build" (
+    docker-compose build app
+)


### PR DESCRIPTION
NOTE: This is a work-in-progress

So i'm making some changes to the base project for a better Windows support and there are several things I'll be doing here:

- [x] Add a configurable port through env variables
- [x] Add a make.bat to simulate `make` commands on windows
- [x] Enable chokidar's polling in make.bat to properly rebuild files when running Docker for Windows
- [ ] Normalize access to both backend and frontend through a load balancer to avoid exposing multiple ports and `GRAPHQL_HOST`-like stuff
- [ ] Enable proper logging and shutdown/failure behaviours by making `nginx` and `php-fpm` both s6 overlay services
- [ ] Cleanup Dockerfile

Also it should solve #7 and #4

BTW, I'd love to hear some feedbacks on this so I can know if this makes sense or not.

Thanks :)